### PR TITLE
Fix compilation with recent ocaml trunk

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -203,7 +203,7 @@ OCAML_LIB(archimedes, [ARCHIMEDES_PATH=$ocaml_lib_path],
 
 
 # Check if OCaml uses custom int types
-AC_CHECK_TYPE([uint32], [CAML_GENERIC_TYPES=1], [], [[#include <caml/config.h>]])
+AC_CHECK_TYPE([int32], [], [CAML_GENERIC_TYPES=1], [[#include "$OCAMLLIBPATH/caml/config.h"]])
 
 if test "$CAML_GENERIC_TYPES" = 1; then
     CFLAGS="$CFLAGS -DCAML_GENERIC_TYPES"

--- a/configure.ac
+++ b/configure.ac
@@ -202,6 +202,12 @@ OCAML_LIB(archimedes, [ARCHIMEDES_PATH=$ocaml_lib_path],
 		      [(Examples will not produce graphics.)])
 
 
+# Check if OCaml uses custom int types
+AC_CHECK_TYPE([uint32], [CAML_GENERIC_TYPES=1], [], [[#include <caml/config.h>]])
+
+if test "$CAML_GENERIC_TYPES" = 1; then
+    CFLAGS="$CFLAGS -DCAML_GENERIC_TYPES"
+fi
 
 if test "$OCAMLOPT" = no ; then
     BEST=byte

--- a/src/bigarray_stubs.c
+++ b/src/bigarray_stubs.c
@@ -1,7 +1,11 @@
+#ifdef CAML_GENERIC_TYPES
+
 #include <stdint.h>
 typedef uint32_t uint32;
 typedef int32_t  int32;
 typedef int64_t  int64;
+
+#endif // CAML_GENERIC_TYPES
 
 /* Verbatim copy of functions in "bigarray_stubs.c" of the OCaml
    distribution that are needed for the specially allocated fftw

--- a/src/bigarray_stubs.c
+++ b/src/bigarray_stubs.c
@@ -1,3 +1,8 @@
+#include <stdint.h>
+typedef uint32_t uint32;
+typedef int32_t  int32;
+typedef int64_t  int64;
+
 /* Verbatim copy of functions in "bigarray_stubs.c" of the OCaml
    distribution that are needed for the specially allocated fftw
    arrays (not defined here).  Everything must be declared


### PR DESCRIPTION
I have the following failure on a recent debian sid:
```
/home/toots/.opam/4.03.0+trunk/bin/ocamlc.opt -c -cc "cc" -ccopt "-fPIC -g -O2 -DFFTW3F_EXISTS -DHASH_EXISTS \
			-DPIC   \
			    -o fftw3_stubs.o " fftw3_stubs.c
In file included from fftw3_stubs.c:44:0:
bigarray_stubs.c: In function ‘caml_ba_compare’:
bigarray_stubs.c:139:27: error: unknown type name ‘int32’
     DO_INTEGER_COMPARISON(int32);
                           ^
bigarray_stubs.c:98:5: note: in definition of macro ‘DO_INTEGER_COMPARISON’
   { type * p1 = b1->data; type * p2 = b2->data; \
     ^
bigarray_stubs.c:139:27: error: unknown type name ‘int32’
     DO_INTEGER_COMPARISON(int32);
                           ^
bigarray_stubs.c:98:27: note: in definition of macro ‘DO_INTEGER_COMPARISON’
   { type * p1 = b1->data; type * p2 = b2->data; \
                           ^
bigarray_stubs.c:139:27: error: unknown type name ‘int32’
     DO_INTEGER_COMPARISON(int32);
                           ^
bigarray_stubs.c:100:7: note: in definition of macro ‘DO_INTEGER_COMPARISON’
       type e1 = *p1++; type e2 = *p2++; \
       ^
bigarray_stubs.c:139:27: error: unknown type name ‘int32’
     DO_INTEGER_COMPARISON(int32);
                           ^
bigarray_stubs.c:100:24: note: in definition of macro ‘DO_INTEGER_COMPARISON’
       type e1 = *p1++; type e2 = *p2++; \
                        ^
bigarray_stubs.c:142:27: error: unknown type name ‘int64’
     DO_INTEGER_COMPARISON(int64);
                           ^
bigarray_stubs.c:98:5: note: in definition of macro ‘DO_INTEGER_COMPARISON’
   { type * p1 = b1->data; type * p2 = b2->data; \
     ^
bigarray_stubs.c:142:27: error: unknown type name ‘int64’
     DO_INTEGER_COMPARISON(int64);
                           ^
bigarray_stubs.c:98:27: note: in definition of macro ‘DO_INTEGER_COMPARISON’
   { type * p1 = b1->data; type * p2 = b2->data; \
                           ^
bigarray_stubs.c:142:27: error: unknown type name ‘int64’
     DO_INTEGER_COMPARISON(int64);
                           ^
bigarray_stubs.c:100:7: note: in definition of macro ‘DO_INTEGER_COMPARISON’
       type e1 = *p1++; type e2 = *p2++; \
       ^
bigarray_stubs.c:142:27: error: unknown type name ‘int64’
     DO_INTEGER_COMPARISON(int64);
                           ^
bigarray_stubs.c:100:24: note: in definition of macro ‘DO_INTEGER_COMPARISON’
       type e1 = *p1++; type e2 = *p2++; \
                        ^
In file included from fftw3_stubs.c:44:0:
bigarray_stubs.c: In function ‘caml_ba_hash’:
bigarray_stubs.c:175:3: error: unknown type name ‘uint32’
   uint32 h, w;
   ^
bigarray_stubs.c:214:5: error: unknown type name ‘uint32’
     uint32 * p = b->data;
     ^
bigarray_stubs.c:229:5: error: unknown type name ‘int64’
     int64 * p = b->data;
     ^
bigarray_stubs.c: In function ‘caml_ba_serialize_longarray’:
bigarray_stubs.c:346:29: error: ‘int32’ undeclared (first use in this function)
       caml_serialize_int_4((int32) *p);
                             ^
bigarray_stubs.c:346:29: note: each undeclared identifier is reported only once for each function it appears in
../OCamlMakefile:1124: recipe for target 'fftw3_stubs.o' failed
```

It's fixed with this PR. I suspect it comes from the C compiler not having the same set of predefined types as before.