### PR TITLE
Add stdint.h include in bigarray.

### DIFF
--- a/src/bigarray_stubs.c
+++ b/src/bigarray_stubs.c
@@ -3,6 +3,8 @@
    arrays (not defined here).  Everything must be declared
    "static". */
 
+#include <stdint.h>
+
 /* From ocaml/byterun/compare.h */
 CAMLextern int caml_compare_unordered;
 
@@ -14,7 +16,6 @@ CAMLextern int caml_compare_unordered;
 #define SIZEOF_BA_ARRAY (sizeof(struct caml_ba_array) - sizeof(intnat))
 #endif
 #endif /* SIZEOF_BA_ARRAY */
-
 
 static uintnat caml_ba_num_elts(struct caml_ba_array * b)
 {


### PR DESCRIPTION
I'm having some compilation issues on alpine linux without it:

```
#=== ERROR while installing fftw3.0.7.2 =======================================#
# opam-version 1.2.2
# os           linux
# command      make
# path         /home/opam/.opam/system/build/fftw3.0.7.2
# compiler     system (4.02.3)
# exit-code    2
# env-file     /home/opam/.opam/system/build/fftw3.0.7.2/fftw3-7029-d2d111.env
# stdout-file  /home/opam/.opam/system/build/fftw3.0.7.2/fftw3-7029-d2d111.out
# stderr-file  /home/opam/.opam/system/build/fftw3.0.7.2/fftw3-7029-d2d111.err
### stdout ###
# [...]
# /usr/bin/ocamldep fftw3_geomC.ml > ._d/fftw3_geomC.d
# /usr/bin/ocamldep fftw3_utils.ml > ._d/fftw3_utils.d
# /usr/bin/ocamlc.opt -c -cc "cc" -ccopt "-fPIC -g -O2 -DFFTW3F_EXISTS -DHASH_EXISTS \
# 			-DPIC   \
# 			    -o fftw3_stubs.o " fftw3_stubs.c
# ../OCamlMakefile:1124: recipe for target 'fftw3_stubs.o' failed
# make[2]: Leaving directory '/home/opam/.opam/system/build/fftw3.0.7.2/src'
# ../OCamlMakefile:784: recipe for target 'byte-code-library' failed
# make[1]: Leaving directory '/home/opam/.opam/system/build/fftw3.0.7.2/src'
# Makefile:19: recipe for target 'all' failed
### stderr ###
# bigarray_stubs.c:223:5: error: unknown type name 'int64_t'
# [...]
#      ^
# bigarray_stubs.c: In function 'caml_ba_serialize_longarray':
# bigarray_stubs.c:340:29: error: 'int32_t' undeclared (first use in this function)
#        caml_serialize_int_4((int32_t) *p);
#                              ^
# bigarray_stubs.c:340:29: note: each undeclared identifier is reported only once for each function it appears in
# make[2]: *** [fftw3_stubs.o] Error 2
# make[1]: *** [byte-code-library] Error 2
# make: *** [all] Error 2
```