### PR TITLE
In configurator, define FFTW3F_EXISTS to enable single-precision tran…

### DIFF
--- a/config/discover.ml
+++ b/config/discover.ml
@@ -102,7 +102,9 @@ let discover c =
   let c_flags =
     if major > 4 || (major = 4 &&  minor >= 6) then "-DOCAML_4_06" :: c_flags
     else c_flags in
-
+  let c_flags =
+    if fftw3f = None then c_flags
+    else "-DFFTW3F_EXISTS" :: c_flags in
   (* if not(check_r2r_kind ~c_flags c) then
    *   C.die "The values of the fields FFTW_R2HC,... in fftw3.h have \
    *          changed.\n  Please use a newer version of the OCaml-fftw3 \


### PR DESCRIPTION
…sforms if package fftw3f is present.

Otherwise I get a "Fftw3.S: single precision C fftwf library not present" exception at runtime.