### PR TITLE
Remove macos special case in opam build rules

### DIFF
--- a/fftw3.opam
+++ b/fftw3.opam
@@ -9,10 +9,7 @@ doc: "https://Chris00.github.io/fftw-ocaml/doc"
 tags: ["FFT"]
 build: [
   ["dune" "subst"] {pinned}
-  ["dune" "build" "-p" name "-j" jobs] {os != "macos"}
-  ["env" "FFTW3_CFLAGS=-I /usr/local/include -L /usr/local/lib -I /usr/local/include -L /usr/local/lib"
-   "dune" "build" "-p" name "-j" jobs
-  ] {os = "macos"}
+  ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [


### PR DESCRIPTION
Hi, I recently tried to install the fftw3 opam package on macos. It was failing with the following build error:

```
# context     2.1.2 | macos/arm64 | ocaml.4.12.0 | https://opam.ocaml.org#82278163
# path        ~/.opam/default/.opam-switch/build/fftw3.0.8.4
# command     ~/.opam/opam-init/hooks/sandbox.sh build env FFTW3_CFLAGS=-I /usr/local/include -L /usr/local/lib -I /usr/local/include -L /usr/local/lib dune build -p fftw3 -j 9
# exit-code   1
# env-file    ~/.opam/log/fftw3-42650-9a28aa.env
# output-file ~/.opam/log/fftw3-42650-9a28aa.out
### output ###
# compiling c program:
# [...]
# run: clang -O2 -fno-strict-aliasing -fwrapv   -DFFTW3F_EXISTS -I /usr/local/include -L /usr/local/lib -I /usr/local/include -L /usr/local/lib -I /opt/homebrew/lib/ocaml -o /var/folders/35/87rc2tbx54l4fqnvcgdfp_lw0000gn/T/buildd0092a.dune/ocaml-configuratorcd31b9/c-test-8/test.o -c /var/folders/35/87rc2tbx54l4fqnvcgdfp_lw0000gn/T/buildd0092a.dune/ocaml-configuratorcd31b9/c-test-8/test.c
# -> process exited with code 1
# -> stdout:
# -> stderr:
#  | clang: warning: argument unused during compilation: '-L/usr/local/lib' [-Wunused-command-line-argument]
#  | clang: warning: argument unused during compilation: '-L/usr/local/lib' [-Wunused-command-line-argument]
#  | /var/folders/35/87rc2tbx54l4fqnvcgdfp_lw0000gn/T/buildd0092a.dune/ocaml-configuratorcd31b9/c-test-8/test.c:2:10: fatal error: 'fftw3.h' file not found
#  | #include <fftw3.h>
#  |          ^~~~~~~~~
#  | 1 error generated.
# Error: failed to compile program



<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><>  🐫
┌─ The following actions failed
│ λ build fftw3 0.8.4
└─
╶─ No changes have been performed
```

I managed to trace the error back to this special case for macos in the opam build rules. If I remove it, the build works fine. I tested this with `opam install .` in my repo.

I'm not sure why this special case was originally introduced. I'm guessing it might have been added to work around a shortcoming in how fftw used to be packaged in brew? From what I can tell now, the standard `fftw` brew package sets up `pkg-config` appropriately, so this special case now only causes issues.